### PR TITLE
lessen php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.0.0",
         "guzzlehttp/guzzle": "~6.0"
     },
     "autoload": {


### PR DESCRIPTION
I don't see any php 7.1 version-specific requirements.

http://php.net/manual/en/migration71.php